### PR TITLE
Fix Kafka container on Apple Silicon (ARM64)

### DIFF
--- a/src/Enhanced.Testing.Component.Kafka/KafkaHarness.cs
+++ b/src/Enhanced.Testing.Component.Kafka/KafkaHarness.cs
@@ -33,7 +33,9 @@ public class KafkaHarness : ContainerHarness<KafkaContainer>
     /// <inheritdoc />
     protected override KafkaContainer OnCreateContainer()
     {
-        return new KafkaBuilder().Build();
+        return new KafkaBuilder()
+            .WithImage("confluentinc/cp-kafka:7.6.1")
+            .Build();
     }
 
     /// <summary>


### PR DESCRIPTION
The default image in Testcontainers.Kafka 3.9.0 is confluentinc/cp-kafka:6.1.9 which only has an amd64 manifest. Override with cp-kafka:7.6.1 which supports both amd64 and arm64 architectures.